### PR TITLE
Update nyzoVerifier.conf

### DIFF
--- a/nyzoVerifier.conf
+++ b/nyzoVerifier.conf
@@ -1,5 +1,5 @@
 [program:nyzo_verifier]
-command=/usr/bin/java -jar -Xmx3G /home/ubuntu/nyzoVerifier/build/libs/nyzoVerifier-1.0.jar
+command=/usr/bin/java -jar -Xmx3G ~/nyzoVerifier/build/libs/nyzoVerifier-1.0.jar
 autostart=true
 autorestart=true
 startsecs=10


### PR DESCRIPTION
We really should have the default directory be whatever the current user is (~) rather than hardcoded as /home/ubuntu. Please advise.

_On second thought, this could break legacy setups that have hardcoded the nyzo verifier to run under /home/ubuntu with another user (i.e. https://medium.com/refortuna/this-short-tutorial-will-explain-in-detail-how-to-set-up-your-own-nyzo-mesh-verifier-node-e799cdf63e6d). We should check in both places instead. Then again, those legacy setups already have nyzoVerifier.conf with the "incorrectly configured location" already in /etc/supervisor/conf.d, so a git pull would not break an existing setup._