### PR TITLE
Minimal fixes to address NCFP-10: Do not allow "red" in-queue verifiers anymore.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,87 @@
+# Open Nyzo verifier changelog
+
+Version is an integer. Open Nyzo uses MMMNNN format, where MMM is the main version number and NNN the Open nyzo subversion number. 
+
+595002 is the recommended version to run if you want to test the "no more red in-queue verifiers".  
+It's the second release candidate based upon official 595.
+
+## Switching to Open Nyzo branch
+
+This is experimental. I did test myself, other Zonys do run that version as well on in-cycle and in-queue verifiers. We think this version is no more unstable than the official version.  
+The changes in code are purposedly minimal and easy to check.  
+
+However - until this is merged into the official repo - running this version is your responsability to take. 
+
+From an existing install:
+```
+rm -rd nyzoVerifier 
+git clone https://github.com/Open-Nyzo/nyzoVerifier.git
+cd nyzoVerifier
+./gradlew build
+supervisorctl reload
+```
+
+On a blank setup, just use that open nyzo git link `https://github.com/Open-Nyzo/nyzoVerifier.git` instead of the official nyzo one and keep the usual install instructions.
+
+If you want a clone setup and compare the drops, then don't forget to also duplicate `/var/lib/nyzo/production/nodes` from old to new install so it does not start empty.
+
+## 595002
+
+v572 introduced communicationFailureCount for Node: https://tech.nyzo.co/releaseNotes/v572
+
+Purpose of communicationFailureCount is to record the number of successive communication attempts failures and mark the peer verifier "inactive" once it reaches a given threshold (6 fails atm).    
+This important data (in regard to red in-queue verifiers) was not persisted.
+
+This means that when restarting a verifier, communicationFailureCount where set at 0 for everyone, no matter the previous count.    
+Since it takes minimum     
+- 2 cycles for a restarted verifier to begin checking the queue  
+- 6 cycles before marking a verifier inactive
+
+Restarting  a verifier means it will not drop any red verifier for at least 8 cycles.   
+
+This version does persist the communicationFailureCount across restarts.
+
+> The unused field from v572 is re-used for that purpose, and ascending compatibility is kept.
+
+At restart, there will still be the 2 cycles wait before testing queue, but then counts will go on from previous state.
+
+As a result, queue clean up will be more efficient and faster, plus spamming/killing nodes to have them restart and thus reset will be a way less effective method.
+
+**Impact on ressources:** None. Uses existing methods, files and field, no sensible impact on verifier load.
+
+
+Additionnaly, 595002 includes more verbose logging for nodejoin messages.   
+By logging ip and short id of nodejoin requests, external scripts and tools are able to automatically id the ips responsible for heavy spamming of nodejoin messages and ban them.
+> It's recommended to have `log_timestamps=true` in `/var/lib/nyzo/production/preferences` file, so that logs come with timestamps.
+
+Example of such log line:  
+`[1595771718.408 (2020-07-26 13:55:18.408 UTC)]: nodejoin_from 46.161.12.140 0049...27cb cookieA12140`
+
+> Please note that nodejoins are a normal part of the protocol and not harmful as such. High volume of such messages however is spam and to be considered as an attack.
+
+
+
+### Upgrading
+
+Nodes running 595001 should *not* restart just to upgrade (would mean 8 cycles loss), however if you plan to restart a 595001 node, as well upgrade to 595002 before restarting.  
+
+
+
+## 595001
+
+First attempt at mitigating red in-queue verifiers.    
+ 
+See https://github.com/n-y-z-o/nyzoVerifier/issues/22  
+This addresses Proposal #1 and is the most minimal answer to the abuses as acknowledged by NCP-10.
+
+Comparison:  
+https://github.com/n-y-z-o/nyzoVerifier/compare/master...Open-Nyzo:master
+
+Main thing here is making sure communicationFailureCount is only reset in answer to a request, and not accessible to fake verifiers only spamming nodejoins messages once in "nodes" file.  
+Seems pretty effective so far, already under testing by several in-cycle verifiers. 
+
+- Nyzo.today sortable list of dropped verifiers https://nyzo.today/dropped
+- Nyzo.today "clean" queue (auto cleaning process still ongoing) https://nyzo.today/queue
+
+> TODO: Integrate more info about current working and the differences. 
+

--- a/src/main/java/co/nyzo/verifier/MeshListener.java
+++ b/src/main/java/co/nyzo/verifier/MeshListener.java
@@ -508,6 +508,9 @@ public class MeshListener {
                     NodeJoinMessageV2 nodeJoinMessage = (NodeJoinMessageV2) message.getContent();
                     NicknameManager.put(message.getSourceNodeIdentifier(), nodeJoinMessage.getNickname());
 
+                    // Log nodejoins so we can filter out obvious spam - Include log_timestamps=true in /var/lib/nyzo/production/preferences
+                    LogUtil.println("nodejoin_from " + IpUtil.addressAsString(message.getSourceIpAddress()) + " " + PrintUtil.compactPrintByteArray(message.getSourceNodeIdentifier()) + " " + nodeJoinMessage.getNickname());
+
                     // Send a UDP ping to help the node ensure that it is receiving UDP messages
                     // properly.
                     Message.sendUdp(message.getSourceIpAddress(), nodeJoinMessage.getPortUdp(),

--- a/src/main/java/co/nyzo/verifier/Message.java
+++ b/src/main/java/co/nyzo/verifier/Message.java
@@ -212,7 +212,6 @@ public class Message {
                     if (socket == null) {
                         NodeManager.markFailedConnection(hostNameOrIp);
                     } else {
-                        NodeManager.markSuccessfulConnection(hostNameOrIp);
 
                         try {
                             OutputStream outputStream = socket.getOutputStream();
@@ -221,6 +220,7 @@ public class Message {
                             socket.setSoTimeout(1000);
                             response = readFromStream(socket.getInputStream(), socket.getInetAddress().getAddress(),
                                     message.getType());
+                            NodeManager.markSuccessfulConnection(hostNameOrIp);
                         } catch (Exception reportOnly) {
                             System.err.println("Exception sending message " + message.getType() + " to " +
                                     hostNameOrIp + ":" + port + ": " + PrintUtil.printException(reportOnly));

--- a/src/main/java/co/nyzo/verifier/Node.java
+++ b/src/main/java/co/nyzo/verifier/Node.java
@@ -74,6 +74,14 @@ public class Node implements MessageObject {
         this.inactiveTimestamp = inactiveTimestamp;
     }
 
+    public long getCommunicationFailureCount() {
+        return communicationFailureCount;
+    }
+
+    public void setCommunicationFailureCount(long communicationFailureCount) {
+        this.communicationFailureCount = communicationFailureCount;
+    }
+
     public boolean isActive() {
         return inactiveTimestamp < 0;
     }

--- a/src/main/java/co/nyzo/verifier/NodeManager.java
+++ b/src/main/java/co/nyzo/verifier/NodeManager.java
@@ -433,7 +433,8 @@ public class NodeManager {
                         node.getPortTcp() + ":" +
                         node.getPortUdp() + ":" +
                         node.getQueueTimestamp() + ":" +
-                        "0:" +  // identifier-change timestamp; no longer used
+                        //"0:" +  // identifier-change timestamp; no longer used
+                        node.getCommunicationFailureCount() + ":" + // slot is now used for communicationFailureCount instead.
                         node.getInactiveTimestamp());
                 separator = "\n";
             }
@@ -469,11 +470,19 @@ public class NodeManager {
                     int portUdp = Integer.parseInt(split[3]);
                     long queueTimestamp = Long.parseLong(split[4]);
                     // long identifierChangeTimestamp = Long.parseLong(split[5]);  no longer used
+                    long communicationFailureCount = Long.parseLong(split[5]);
+                    if (communicationFailureCount > 1000) {
+                        // Extra precaution only in case of someone using a very old nodes file.
+                        // old nodes files with a timestamp there will be considered as Zero failed attempt.
+                        // 1000 is low enough not to be a timestamp, and high enough not to be a real fail count.
+                        communicationFailureCount = 0;
+                    }
                     long inactiveTimestamp = Long.parseLong(split[6]);
 
                     Node node = new Node(identifier, ipAddress, portTcp, portUdp);
                     node.setQueueTimestamp(queueTimestamp);
                     node.setInactiveTimestamp(inactiveTimestamp);
+                    node.setCommunicationFailureCount(communicationFailureCount);
 
                     ipAddressToNodeMap.put(ByteBuffer.wrap(ipAddress), node);
                 } catch (Exception ignored) { }

--- a/src/main/java/co/nyzo/verifier/NodeManager.java
+++ b/src/main/java/co/nyzo/verifier/NodeManager.java
@@ -68,7 +68,12 @@ public class NodeManager {
             // typically made when a node comes back online after a temporary network issue.
             Node node = ipAddressToNodeMap.get(ByteBuffer.wrap(message.getSourceIpAddress()));
             if (node != null) {
-                node.markSuccessfulConnection();
+                ByteBuffer identifierBuffer = ByteBuffer.wrap(node.getIdentifier());
+                if (BlockManager.verifierInCurrentCycle(identifierBuffer)) {
+                    node.markSuccessfulConnection();
+                } else {
+                    LogUtil.println("Missing block request from out of cycle in updateNode(): " + NicknameManager.get(node.getIdentifier()));
+                }
             }
         } else {
             LogUtil.println("unrecognized message type in updateNode(): " + message.getType());
@@ -96,7 +101,9 @@ public class NodeManager {
                 if (portUdp > 0) {
                     existingNode.setPortUdp(portUdp);
                 }
-                existingNode.markSuccessfulConnection();
+                if (isNodeJoinResponse) {
+                    existingNode.markSuccessfulConnection();
+                }
             } else {
                 // If the existing node is not null, remove it.
                 if (existingNode != null) {

--- a/src/main/java/co/nyzo/verifier/Version.java
+++ b/src/main/java/co/nyzo/verifier/Version.java
@@ -2,7 +2,7 @@ package co.nyzo.verifier;
 
 public class Version {
 
-    private static final int version = 595;
+    private static final int version = 595001;
 
     public static int getVersion() {
 

--- a/src/main/java/co/nyzo/verifier/Version.java
+++ b/src/main/java/co/nyzo/verifier/Version.java
@@ -2,7 +2,7 @@ package co.nyzo.verifier;
 
 public class Version {
 
-    private static final int version = 595001;
+    private static final int version = 595002;
 
     public static int getVersion() {
 


### PR DESCRIPTION
Reference:  
https://github.com/n-y-z-o/nyzoVerifier/issues/22

By voting Yes to ncfp-10, current cycle acknowledged the issue with always red verifiers being able to remain in queue with no actual verifier running, just spamming nodejoins once in "nodes" file.

This patch does 
- persist the new communicationFailureCount metric in nodes file.  
- rebalance increment/reset of failure count by reseting communicationFailureCount on successful answer only, never on incoming messages alone.  
- log nodejoins messages in a more verbose way, so external scripts can use that info (ip and short-id) to auto-ban or rate limit spamming nodes.  
- adds some context in changelog.md

This version has been tested since several days on several verifiers (both in-cycle and in-queue).  
v596 and 597 have been integrated since so this PR can be merge with no conflict.

A preview of what the eligible (> 30 days) nyzo queue would look like if present at  https://nyzo.today/queue  from a modded verifier.  
https://nyzo.today/dropped is a searchable table of "dropped" verifiers (nodes that are in the original nodes file but dropped from the modded version due to being consistently inactive for too long)

The difference with current nyzo queue is striking, and no false positive was reported so far.  
This is just a first step to address huge number of verifiers abusing current code, but in no way a definitive answer.  
This only patches today's most urging issue in the most minimal and side effect proof way.